### PR TITLE
[CP-556] Add READONLY command support for Redis Cluster replica connections

### DIFF
--- a/src/eredis.erl
+++ b/src/eredis.erl
@@ -84,8 +84,10 @@ start_link(Args) ->
     ConnectTimeout = proplists:get_value(connect_timeout, Args, ?TIMEOUT),
     SocketOptions  = proplists:get_value(socket_options, Args, []),
     IsSSL          = proplists:get_value(ssl, Args, false),
+    Readonly       = proplists:get_value(readonly, Args, false),
 
-    start_link(Host, Port, Database, Password, ReconnectSleep, ConnectTimeout, true, SocketOptions, IsSSL).
+    eredis_client:start_link(Host, Port, Database, Password,
+        ReconnectSleep, ConnectTimeout, true, SocketOptions, IsSSL, Readonly).
 
 stop(Client) ->
     eredis_client:stop(Client).

--- a/src/eredis_client.erl
+++ b/src/eredis_client.erl
@@ -25,7 +25,7 @@
 -include("eredis.hrl").
 
 %% API
--export([start_link/9, stop/1, select_database/3]).
+-export([start_link/9, start_link/10, stop/1, select_database/3]).
 
 -export([do_sync_command/3]).
 
@@ -42,6 +42,7 @@
     reconnect_sleep :: reconnect_sleep() | undefined,
     connect_timeout :: integer() | undefined,
     socket_options :: list(),
+    readonly = false :: boolean(),
     sync_start :: boolean(),
     sync_start_retries = 5 :: pos_integer(),
     socket :: port() | undefined,
@@ -67,6 +68,23 @@ start_link(Host, Port, Database, Password, ReconnectSleep, ConnectTimeout, SyncS
     gen_server:start_link(?MODULE, [Host, Port, Database, Password,
                                     ReconnectSleep, ConnectTimeout, SyncStart, SocketOptions, IsSSL], []).
 
+start_link(Host, Port, Database, Password, ReconnectSleep,
+           ConnectTimeout, SyncStart, SocketOptions, IsSSL, Readonly)
+  when is_list(Host) orelse
+       (is_tuple(Host) andalso tuple_size(Host) =:= 2 andalso
+        element(1, Host) =:= local),
+       is_integer(Port),
+       is_integer(Database) orelse Database == undefined,
+       is_list(Password),
+       is_integer(ReconnectSleep) orelse ReconnectSleep =:= no_reconnect,
+       is_integer(ConnectTimeout),
+       is_boolean(SyncStart),
+       is_list(SocketOptions),
+       is_boolean(Readonly) ->
+    gen_server:start_link(?MODULE, [Host, Port, Database, Password,
+        ReconnectSleep, ConnectTimeout, SyncStart, SocketOptions,
+        IsSSL, Readonly], []).
+
 
 stop(Pid) ->
     gen_server:call(Pid, stop).
@@ -76,6 +94,9 @@ stop(Pid) ->
 %%====================================================================
 
 init([Host, Port, Database, Password, ReconnectSleep, ConnectTimeout, SyncStart, SocketOptions, IsSSL]) ->
+    init([Host, Port, Database, Password, ReconnectSleep, ConnectTimeout, SyncStart, SocketOptions, IsSSL, false]);
+
+init([Host, Port, Database, Password, ReconnectSleep, ConnectTimeout, SyncStart, SocketOptions, IsSSL, Readonly]) ->
     State = #state{host = Host,
         port = Port,
         database = read_database(Database),
@@ -84,6 +105,7 @@ init([Host, Port, Database, Password, ReconnectSleep, ConnectTimeout, SyncStart,
         reconnect_sleep = ReconnectSleep,
         connect_timeout = ConnectTimeout,
         socket_options = SocketOptions,
+        readonly = Readonly,
         sync_start = SyncStart,
         parser_state = eredis_parser:init(),
         queue = queue:new()},
@@ -321,7 +343,12 @@ connect(State) ->
                 ok ->
                     case select_database(Socket, State#state.database, State#state.is_ssl) of
                         ok ->
-                            {ok, State#state{socket = Socket}};
+                            case set_readonly(Socket, State#state.readonly, State#state.is_ssl) of
+                                ok ->
+                                    {ok, State#state{socket = Socket}};
+                                {error, Reason} ->
+                                    {error, {readonly_error, Reason}}
+                            end;
                         {error, Reason} ->
                             {error, {select_error, Reason}}
                     end;
@@ -358,6 +385,11 @@ select_database(_Socket, <<"0">>, _IsSSL) ->
     ok;
 select_database(Socket, Database, IsSSL) ->
     do_sync_command(Socket, ["SELECT", " ", Database, "\r\n"], IsSSL).
+
+set_readonly(_Socket, false, _IsSSL) ->
+    ok;
+set_readonly(Socket, true, IsSSL) ->
+    do_sync_command(Socket, ["READONLY", "\r\n"], IsSSL).
 
 authenticate(_Socket, <<>>, _IsSSL) ->
     ok;


### PR DESCRIPTION
# Description

Adds a `readonly` option to `eredis_client` so that connections destined for Redis Cluster replica nodes send the `READONLY` command on connect. Required so replica reads don't get rejected by Redis (Cluster replicas reject reads by default). Consumed by the companion change in `eredis_cluster_tmp` (`jcruz/CP-556`), which creates dedicated replica pools and routes read-only commands to them.

## Type

- 🚀 Feature

## Changes

- **`src/eredis_client.erl`** — Add `readonly` field to `#state{}` record; add `start_link/10` with `Readonly` parameter; add backward-compatible 9-arg dispatch in `init/1`; add `set_readonly/3` helper that issues `READONLY` after connect; update `connect/1` to invoke `set_readonly` on every connection so all four reconnect paths are covered.
- **`src/eredis.erl`** — Update the poolboy worker callback to extract the `readonly` option from `WorkerArgs` and forward it to `start_link/10`.

## Related Tickets

- [CP-556](https://tigertext.atlassian.net/browse/CP-556)

## Notes

- Fully backward compatible: callers that don't pass `readonly` continue to use `start_link/9` and behave as before (no `READONLY` sent).
- `READONLY` is sent on every (re)connection, so replica-designated clients stay in read-only mode after transient disconnects.
- Consumed by `tigertext/eredis_cluster_tmp` branch `jcruz/CP-556` and `tigertext/xmpp` PR #12624.

[CP-556]: https://tigertext.atlassian.net/browse/CP-556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ